### PR TITLE
Switch to gcloud ADC instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ $ git clone https://github.com/context-labs/autodoc.git
 $ cd autodoc
 ```
 
-Right now Autodoc only supports Google's Gemini models. Make sure you have your Google API key exported in your current session:
+Right now Autodoc only supports Google's Gemini models. Make sure you have
+authenticated using [Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc):
 
 ```bash
-$ export GOOGLE_API_KEY=<YOUR_KEY_HERE>
+$ gcloud auth application-default login
 ```
 
 To start the Autodoc query CLI, run:
@@ -116,10 +117,10 @@ Change directory into the root of your project:
 ```bash
 cd $PROJECT_ROOT
 ```
-Make sure your Google API key is available in the current session:
+Make sure you are authenticated with Application Default Credentials:
 
 ```bash
-$ export GOOGLE_API_KEY=<YOUR_KEY_HERE>
+$ gcloud auth application-default login
 ```
 
 Run the `init` command:

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-hooks": "^4.2.0",
         "prettier": "^2.7.1",
-        "typescript": "^4.8.3"
+        "typescript": "^5.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5466,16 +5466,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -9459,9 +9460,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "prettier": "^2.7.1",
-    "typescript": "^4.8.3"
+    "typescript": "^5.4.0"
   }
 }

--- a/src/cli/commands/index/convertJsonToMarkdown.ts
+++ b/src/cli/commands/index/convertJsonToMarkdown.ts
@@ -5,7 +5,7 @@ import {
   FileSummary,
   FolderSummary,
   ProcessFile,
-} from '../../../types';
+} from '../../../types.js';
 import { traverseFileSystem } from '../../utils/traverseFileSystem.js';
 import { spinnerSuccess, updateSpinnerText } from '../../spinner.js';
 import { getFileName } from '../../utils/FileUtil.js';
@@ -46,6 +46,9 @@ export const convertJsonToMarkdown = async ({
   const processFile: ProcessFile = async ({
     fileName,
     filePath,
+  }: {
+    fileName: string;
+    filePath: string;
   }): Promise<void> => {
     const content = await fs.readFile(filePath, 'utf-8');
 

--- a/src/cli/commands/index/processRepository.ts
+++ b/src/cli/commands/index/processRepository.ts
@@ -56,7 +56,10 @@ export const processRepository = async (
     prompt: string,
     model: ChatGoogleGenerativeAI,
   ): Promise<string> => {
-    return rateLimit.callApi(() => model.invoke(prompt));
+    const res = await rateLimit.callApi(() => model.invoke(prompt));
+    // `invoke` returns an AIMessageChunk; extract the content string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (res as any).content ?? res;
   };
 
   const isModel = (model: LLMModelDetails | null): model is LLMModelDetails =>

--- a/src/cli/commands/init/index.ts
+++ b/src/cli/commands/init/index.ts
@@ -15,7 +15,7 @@ export const makeConfigTemplate = (
     llms:
       config?.llms?.length ?? 0 > 0
         ? (config as AutodocRepoConfig).llms
-        : [LLMModels.GPT3],
+        : [LLMModels.GEMINI_PRO],
     priority: Priority.COST,
     maxConcurrentCalls: 25,
     addQuestions: true,
@@ -95,25 +95,17 @@ export const init = async (
       type: 'list',
       name: 'llms',
       message: chalk.yellow(
-        `Select which LLMs you have access to (use GPT-3.5 Turbo if you aren't sure):`,
+        `Select which LLMs you have access to (use gemini-2.5-pro if you aren't sure):`,
       ),
       default: 0,
       choices: [
         {
-          name: 'GPT-3.5 Turbo',
-          value: [LLMModels.GPT3],
+          name: 'Gemini 2.5 Pro',
+          value: [LLMModels.GEMINI_PRO],
         },
         {
-          name: 'GPT-3.5 Turbo, GPT-4 8K (Early Access)',
-          value: [LLMModels.GPT3, LLMModels.GPT4],
-        },
-        {
-          name: 'GPT-3.5 Turbo, GPT-4 8K (Early Access), GPT-4 32K (Early Access)',
-          value: [LLMModels.GPT3, LLMModels.GPT4, LLMModels.GPT432k],
-        },
-        {
-          name: 'GPT-4o, GPT-4o-mini',
-          value: [LLMModels.GPT4o, LLMModels.GPT4omini],
+          name: 'Gemini 2.5 Pro Vision',
+          value: [LLMModels.GEMINI_PRO_VISION],
         },
       ],
     },

--- a/src/cli/commands/query/createChatChain.ts
+++ b/src/cli/commands/query/createChatChain.ts
@@ -56,11 +56,11 @@ export const makeChain = (
   onTokenStream?: (token: string) => void,
 ) => {
   /**
-   * GPT-4 or GPT-3
+   * Gemini Pro or Gemini Pro Vision
    */
   const llm = llms?.[1] ?? llms[0];
   const questionGenerator = new LLMChain({
-    llm: new ChatGoogleGenerativeAI({ model: llm, temperature: 0.1 }),
+    llm: new ChatGoogleGenerativeAI({ model: llm, temperature: 0.1 }) as any,
     prompt: CONDENSE_PROMPT,
   });
 
@@ -71,12 +71,10 @@ export const makeChain = (
       model: llm,
       temperature: 0.2,
       streaming: Boolean(onTokenStream),
-      callbackManager: {
-        handleLLMNewToken: onTokenStream,
-        handleLLMStart: () => null,
-        handleLLMEnd: () => null,
-      } as any,
-    }),
+      callbacks: onTokenStream
+        ? [{ handleLLMNewToken: onTokenStream }]
+        : undefined,
+    }) as any,
     { prompt: QA_PROMPT },
   );
 

--- a/src/cli/commands/user/index.ts
+++ b/src/cli/commands/user/index.ts
@@ -9,7 +9,7 @@ export const makeConfigTemplate = (
   config?: AutodocUserConfig,
 ): AutodocUserConfig => {
   return {
-    llms: config?.llms ?? [LLMModels.GPT3],
+    llms: config?.llms ?? [LLMModels.GEMINI_PRO],
   };
 };
 
@@ -47,25 +47,17 @@ export const user = async (
       type: 'list',
       name: 'llms',
       message: chalk.yellow(
-        `Select which LLMs you have access to (use GPT-3.5 Turbo if you aren't sure):`,
+        `Select which LLMs you have access to (use gemini-2.5-pro if you aren't sure):`,
       ),
       default: 0,
       choices: [
         {
-          name: 'GPT-3.5 Turbo',
-          value: [LLMModels.GPT3],
+          name: 'Gemini 2.5 Pro',
+          value: [LLMModels.GEMINI_PRO],
         },
         {
-          name: 'GPT-3.5 Turbo, GPT-4 8K (Early Access)',
-          value: [LLMModels.GPT3, LLMModels.GPT4],
-        },
-        {
-          name: 'GPT-3.5 Turbo, GPT-4 8K (Early Access), GPT-4 32K (Early Access)',
-          value: [LLMModels.GPT3, LLMModels.GPT4, LLMModels.GPT432k],
-        },
-        {
-          name: 'GPT-4o, GPT-4o-mini',
-          value: [LLMModels.GPT4o, LLMModels.GPT4omini],
+          name: 'Gemini 2.5 Pro Vision',
+          value: [LLMModels.GEMINI_PRO_VISION],
         },
       ],
     },

--- a/src/cli/utils/traverseFileSystem.ts
+++ b/src/cli/utils/traverseFileSystem.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'path';
 import minimatch from 'minimatch';
-import { isText } from 'istextorbinary';
+import { isTextSync } from 'istextorbinary';
 import { TraverseFileSystemParams } from '../../types.js';
 
 export const traverseFileSystem = async (
@@ -71,7 +71,7 @@ export const traverseFileSystem = async (
 
           const buffer = await fs.readFile(filePath);
 
-          if (isText(fileName, buffer)) {
+          if (isTextSync(fileName, buffer)) {
             await processFile?.({
               fileName,
               filePath,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,13 @@
     "outDir": "dist",
     "strict": true,
     "target": "es2020",
-    "module": "ES2020",
+    "module": "NodeNext",
     "sourceMap": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "declaration": true,
-    "skipLibCheck": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Summary
- advise using `gcloud auth application-default login`
- compile with `typescript@5` and NodeNext settings
- drop old GPT choices for Gemini models
- fix TypeScript build errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b6c055c0c832a8093b7b21bca1e25